### PR TITLE
Fix rotation on Android, using EXIF data

### DIFF
--- a/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
+++ b/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
@@ -9,6 +9,7 @@ import android.graphics.Paint;
 import android.graphics.PointF;
 import android.graphics.PorterDuff;
 import android.graphics.Rect;
+import android.media.ExifInterface;
 import android.os.Environment;
 import android.util.Base64;
 import android.util.Log;
@@ -69,10 +70,30 @@ public class SketchCanvas extends View {
                 "drawable", 
                 mContext.getPackageName());
             BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
+            File file = new File(filename, directory == null ? "" : directory);
             Bitmap bitmap = res == 0 ? 
-                BitmapFactory.decodeFile(new File(filename, directory == null ? "" : directory).toString(), bitmapOptions) :
+                BitmapFactory.decodeFile(file.toString(), bitmapOptions) :
                 BitmapFactory.decodeResource(mContext.getResources(), res);
-            if(bitmap != null) {
+
+            try {
+                ExifInterface exif = new ExifInterface(file.getAbsolutePath());
+                Matrix matrix = new Matrix();
+
+                int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 1);
+                if (orientation == ExifInterface.ORIENTATION_ROTATE_90) {
+                    matrix.postRotate(90);
+                } else if (orientation == ExifInterface.ORIENTATION_ROTATE_180) {
+                    matrix.postRotate(180);
+                } else if (orientation == ExifInterface.ORIENTATION_ROTATE_270) {
+                    matrix.postRotate(270);
+                }
+
+                myBitmap = Bitmap.createBitmap(myBitmap, 0, 0, myBitmap.getWidth(), myBitmap.getHeight(), matrix, true); // rotating bitmap
+            } catch (Exception e) {
+                
+            }
+
+            if (bitmap != null) {
                 mBackgroundImage = bitmap;
                 mOriginalHeight = bitmap.getHeight();
                 mOriginalWidth = bitmap.getWidth();

--- a/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
+++ b/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
@@ -9,6 +9,7 @@ import android.graphics.Paint;
 import android.graphics.PointF;
 import android.graphics.PorterDuff;
 import android.graphics.Rect;
+import android.graphics.Matrix;
 import android.media.ExifInterface;
 import android.os.Environment;
 import android.util.Base64;
@@ -88,9 +89,9 @@ public class SketchCanvas extends View {
                     matrix.postRotate(270);
                 }
 
-                myBitmap = Bitmap.createBitmap(myBitmap, 0, 0, myBitmap.getWidth(), myBitmap.getHeight(), matrix, true); // rotating bitmap
+                bitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true); // rotating bitmap
             } catch (Exception e) {
-                
+
             }
 
             if (bitmap != null) {


### PR DESCRIPTION
Some Android phones have their camera sensors mounted sideways, upside down, ect. The BitmapFactory#decodeFile method does not take this into account, by default. So, when the file is decoded, it could end up getting shown in an incorrect orientation on the canvas.

iOS manages this correctly already. This PR just fixes the issue for Android devices.